### PR TITLE
Add job name setting (for STDIN or override)

### DIFF
--- a/qbatch
+++ b/qbatch
@@ -54,6 +54,9 @@ if __name__ == "__main__":
                         help="Dry run; nothing is submitted")
     parser.add_argument("--afterok_pattern", action="append",
                         help="Existing jobs matching the given pattern as dependencies.")
+    parser.add_argument("--jobname", action="store",
+                        help="Override default job name generated from command_file, or set name for STDIN jobs")
+
 
     args = parser.parse_args()
 
@@ -69,10 +72,9 @@ if __name__ == "__main__":
     ppn = args.ppn
     afterok_pattern = args.afterok_pattern
     highmem = args.highmem
+    job_name = args.jobname
 
     # read in commands
-    job_name = None
-
     if command_file == '-':
         job_name = job_name or 'STDIN'
         task_list = sys.stdin.readlines()
@@ -104,6 +106,7 @@ if __name__ == "__main__":
             "#PBS -l nodes={nodes}{highmem}:ppn={ppn}",
             "#PBS -V",
             "#PBS -d {workdir}",
+            "#PBS -N {jobname}",
             "#PBS {options}",
             "#PBS {array}",
             "{dependencies}",
@@ -113,6 +116,7 @@ if __name__ == "__main__":
             ppn=ppn,
             shebang=shebang,
             workdir=job_workdir,
+            jobname=job_name,
             options=' '.join(qsub_options),
             array=use_array and '-t 1-' + str(num_jobs) or '',
             dependencies=matching_jobids and '#PBS -W depend=afterok:' + ':'.join(matching_jobids) or '')
@@ -123,6 +127,7 @@ if __name__ == "__main__":
             "{ppn}",
             "#$ -V",
             "#$ -wd {workdir}",
+            "#$ -N {jobname}",
             "#$ {options}",
             "#$ {array}",
             "{dependencies}",
@@ -130,6 +135,7 @@ if __name__ == "__main__":
             ppn=(ppn > 1) and '#$ -pe smp ' + ppn or '',
             shebang=shebang,
             workdir=job_workdir,
+            jobname=job_name,
             options=' '.join(qsub_options),
             array=use_array and '-t 1-' + str(num_jobs) or '',
             dependencies=afterok_pattern and '#$ -hold_jid ' + afterok_pattern or '')


### PR DESCRIPTION
This is also essential for LSF as it only handles magics via STDIN to its bsub commands.