### PR TITLE
Handle cases of number of commands less than chunks, and single commands

### DIFF
--- a/bin/qbatch
+++ b/bin/qbatch
@@ -330,6 +330,11 @@ if __name__ == "__main__":
         use_array = False
         num_jobs = 1
         chunk_size = sys.maxsize
+    elif len(task_list) <= chunk_size:
+        use_array = False
+        num_jobs = 1
+        print >>sys.stderr, "Number of commands less than chunk size, " \
+                            "building single non-array job"
     else:
         num_jobs = int(math.ceil(len(task_list) / float(chunk_size)))
 
@@ -399,13 +404,18 @@ if __name__ == "__main__":
         for chunk in range(num_jobs):
             scriptfile = os.path.join(
                 SCRIPT_FOLDER, "{0}.{1}".format(job_name, chunk))
-            script_lines = [
-                header,
-                'CORES={0}'.format(ncores),
-                "parallel -j${CORES} << EOF",
-                ''.join(task_list[chunk * chunk_size:chunk *
-                                  chunk_size + chunk_size]),
-                'EOF']
+            if len(task_list) == 1:
+                script_lines = [
+                    header,
+                    ''.join(task_list)]
+            else:
+                script_lines = [
+                    header,
+                    'CORES={0}'.format(ncores),
+                    "parallel -j${CORES} << EOF",
+                    ''.join(task_list[chunk * chunk_size:chunk *
+                                      chunk_size + chunk_size]),
+                    'EOF']
             script = open(scriptfile, "w")
             script.write('\n'.join(script_lines))
             script.close()

--- a/test/test_qbatch.py
+++ b/test/test_qbatch.py
@@ -32,13 +32,13 @@ def test_qbatch_help():
     assert p.returncode == 0, err
 
 
-def test_run_qbatch_dryrun_array_output_exists():
+def test_run_qbatch_dryrun_single_output_exists():
     cmds = "\n".join(["echo hello"])
     p = command_pipe('qbatch -n -')
     out, err = p.communicate(cmds)
 
     assert p.returncode == 0
-    assert exists(join(tempdir, 'STDIN.array'))
+    assert exists(join(tempdir, 'STDIN.0'))
 
 
 def test_run_qbatch_sge_dryrun_array_piped_chunks():


### PR DESCRIPTION
This change detects the special case of commands being less than the chunksize, and switches to a non-array job.

It also detects the case of a single command, and forgoes wrapping it in a parallel call.