### PR TITLE
Convert test equality to sets to allow out-of-order execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: required
-dist: trusty
+sudo: require
+dist: false
 
 language: python
 python: 

--- a/test/test_qbatch.py
+++ b/test/test_qbatch.py
@@ -63,7 +63,7 @@ def test_run_qbatch_sge_dryrun_array_piped_chunks():
 
         assert array_pipe.returncode == 0, \
             "Chunk {0}: return code = {1}".format(chunk, array_pipe.returncode)
-        assert out.decode('UTF-8') == expected, \
+        assert set(out.decode('UTF-8').split('\n')) == set(expected.split('\n')), \
             "Chunk {0}: Expected {1} but got {2}".format(chunk, expected, out)
 
 
@@ -90,7 +90,7 @@ def test_run_qbatch_pbs_dryrun_array_piped_chunks():
 
         assert array_pipe.returncode == 0, \
             "Chunk {0}: return code = {1}".format(chunk, array_pipe.returncode)
-        assert out.decode('UTF-8') == expected, \
+        assert set(out.decode('UTF-8').split('\n')) == set(expected.split('\n')), \
             "Chunk {0}: Expected {1} but got {2}".format(chunk, expected, out)
 
 
@@ -104,5 +104,5 @@ def test_run_qbatch_local_piped_commands():
 
     assert p.returncode == 0, \
         "Return code = {0}".format(err)
-    assert out == expected, \
+    assert set(out.split('\n')) == set(expected.split('\n')), \
         "Expected {0} but got {1}".format(expected, out)


### PR DESCRIPTION
Convert tests to use sets.

Will manually re-run travis a few times to see if this fixes the random errors.
