### PR TITLE
Checks presence of queue binary before submitting jobs

### DIFF
--- a/qbatch/qbatch.py
+++ b/qbatch/qbatch.py
@@ -26,19 +26,6 @@ def _setupVars():
     # setup defaults (let environment override)
     global SYSTEM
     SYSTEM = os.environ.get("QBATCH_SYSTEM", "local")
-    if SYSTEM == "slurm":
-        which('sbatch') or sys.exit("qbatch: error: QBATCH_SYSTEM set to slurm"
-                                    " but sbatch not found")
-        which('squeue') or sys.exit("qbatch: error: QBATCH_SYSTEM set to slurm"
-                                    " but squeue not found")
-    elif (SYSTEM == "pbs") or (SYSTEM == "sge"):
-        which('qsub') or sys.exit("qbatch: error: QBATCH_SYSTEM set to pbs/sge"
-                                  " but qsub not found")
-        which('qstat') or sys.exit("qbatch: error: QBATCH_SYSTEM set to"
-                                   " pbs/sge but qstat not found")
-    else:
-        which('parallel') or sys.exit("qbatch: error: QBATCH_SYSTEM set to"
-                                      " local but parallel not found")
     global PPJ
     PPJ = os.environ.get("QBATCH_PPJ", "1")
     global CHUNKSIZE
@@ -546,6 +533,21 @@ def qbatchDriver(**kwargs):
                 script.write(footer_commands)
             script.close()
             job_scripts.append(scriptfile)
+
+    # preflight checks
+    if SYSTEM == "slurm":
+        which('sbatch') or sys.exit("qbatch: error: QBATCH_SYSTEM set to slurm"
+                                    " but sbatch not found")
+        which('squeue') or sys.exit("qbatch: error: QBATCH_SYSTEM set to slurm"
+                                    " but squeue not found")
+    elif (SYSTEM == "pbs") or (SYSTEM == "sge"):
+        which('qsub') or sys.exit("qbatch: error: QBATCH_SYSTEM set to pbs/sge"
+                                  " but qsub not found")
+        which('qstat') or sys.exit("qbatch: error: QBATCH_SYSTEM set to"
+                                   " pbs/sge but qstat not found")
+    else:
+        which('parallel') or sys.exit("qbatch: error: QBATCH_SYSTEM set to"
+                                      " local but parallel not found")
 
     # execute the job script(s)
     for script in job_scripts:

--- a/test/test_qbatch.py
+++ b/test/test_qbatch.py
@@ -42,6 +42,24 @@ def test_qbatch_help():
     assert p.returncode == 0, p.returncode
 
 
+def test_qbatch_help_no_queue_binary():
+    """Tests that --help works when there is no queuing binary available.
+
+    If QBATCH_SYSTEM is not 'local', using --help should still work.
+
+    This tests for the following issue:
+        https://github.com/pipitone/qbatch/issues/177
+    """
+
+    os.environ['QBATCH_SYSTEM'] = 'slurm'
+    try:
+        p = command_pipe('qbatch --help')
+        out, _ = p.communicate(''.encode('utf-8'))
+        assert p.returncode == 0, p.returncode
+    finally:
+        del os.environ['QBATCH_SYSTEM']
+
+
 def test_python_import():
     p = command_pipe('python -c "from qbatch import qbatchParser"')
     out, _ = p.communicate(''.encode('utf-8'))


### PR DESCRIPTION
This change fixes #177 where running --help with the QBATCH_SYSTEM
environment variable set, but no queuing system binary in the path, will
cause qbatch to exit with an error message but not display help.

A test case is provided here that does not quite follow unit testing
conventions in that it does teardown within the function via
try..finally. I opted for this because it seemed less unwieldy compared
to importing the nose module and attaching a separate teardown function.