### PR TITLE
Fix submission breakage with a single job

### DIFF
--- a/qbatch/qbatch.py
+++ b/qbatch/qbatch.py
@@ -345,7 +345,7 @@ def qbatchDriver(**kwargs):
     if not kwargs.get('task_list'):
         if command_file[0] == '--':
             if (len(command_file) > 1):
-                task_list = " ".join(command_file[1:])
+                task_list = [" ".join(command_file[1:])]
                 job_name = job_name or command_file[1]
             else:
                 sys.exit("qbatch: error: no command provided as last argument")


### PR DESCRIPTION
The len here was breaking when a single command was issued submitting nchar versions of the single job. @nzxwang fixed it.