### PR TITLE
Fix slurm squeue listing

### DIFF
--- a/qbatch/qbatch.py
+++ b/qbatch/qbatch.py
@@ -263,9 +263,8 @@ def slurm_find_jobs(patterns):
         patterns = [patterns]
 
     output = subprocess.check_output(
-        ['squeue', '-h', '--user=$USER', '--states=PD,R,S,CF',
-         '--format="%j %A"'],
-        shell=True).decode('utf-8')
+        ['squeue', '-h', '--user={}'.format(os.environ.get("USER")),
+         '--states=PD,R,S,CF', '--format="%j100 %A"']).decode('utf-8')
     if not output:
         print(
             "qbatch: warning: Dependencies specified but no running"


### PR DESCRIPTION
SLURM is a bit brain dead with its default widths for things, it seems that if you start tweaking with the format line, suddenly the lengths of things get shorter so parsing was no longer working properly.

On top of this shell=True changes the parsing of the list of commands and so that the shell was taking them as arguments instead of squeue, so a bit mess here.

Avoid shell=True by using os.environ.get for the username and allow for very long job  names.