### PR TITLE
Explicitly embed the launch shell in PBS and SGE commands

### DIFF
--- a/qbatch/qbatch.py
+++ b/qbatch/qbatch.py
@@ -59,6 +59,7 @@ def _setupVars():
     PBS_HEADER_TEMPLATE = dedent(
         """\
     #!{shell}
+    #PBS -S {shell}
     #PBS -l nodes={nodes}:{nodes_spec}ppn={ppj}
     #PBS -j oe
     #PBS -o {logdir}
@@ -80,6 +81,7 @@ def _setupVars():
     SGE_HEADER_TEMPLATE = dedent(
         """\
     #!{shell}
+    #$ -S {shell}
     #$ {ppj}
     #$ -j y
     #$ -o {logdir}


### PR DESCRIPTION
Seems there's some corner cases in old clusters, where the first line, the shebang which defines the shell runner, is ignored in favour of the default shell configured for the cluster. This is in fact the case at the CIC, however the default shell was ``/bin/bash`` so everything was fine.

In older clusters, the default shell is often ``/bin/csh`` which doesn't at all support the shellscripting tricks we're using to do array jobs, or even the export command, so things would just die.

cc @egarza