### PR TITLE
Cleanup missing command checks

### DIFF
--- a/qbatch/qbatch.py
+++ b/qbatch/qbatch.py
@@ -480,7 +480,7 @@ def qbatchDriver(**kwargs):
     if use_array:
         script_lines = [
             header,
-            'which parallel > /dev/null 2>&1 || { echo "GNU parallel not '
+            'command -v parallel > /dev/null 2>&1 || { echo "GNU parallel not '
             'found in job environment. Exiting."; exit 1; }',
             'CHUNK_SIZE={0}'.format(chunk_size),
             'CORES={0}'.format(ncores),
@@ -515,7 +515,7 @@ def qbatchDriver(**kwargs):
             else:
                 script_lines = [
                     header,
-                    'which parallel > /dev/null 2>&1 || { echo "GNU parallel'
+                    'command -v parallel > /dev/null 2>&1 || { echo "GNU parallel'
                     ' not found in job environment. Exiting."; exit 1; }',
                     'CORES={0}'.format(ncores),
                     'export THREADS_PER_COMMAND={0}'.format(

--- a/qbatch/qbatch.py
+++ b/qbatch/qbatch.py
@@ -515,8 +515,9 @@ def qbatchDriver(**kwargs):
             else:
                 script_lines = [
                     header,
-                    'command -v parallel > /dev/null 2>&1 || { echo "GNU parallel'
-                    ' not found in job environment. Exiting."; exit 1; }',
+                    'command -v parallel > /dev/null 2>&1 || { echo "GNU'
+                    ' parallel not found in job environment. Exiting.";'
+                    ' exit 1; }',
                     'CORES={0}'.format(ncores),
                     'export THREADS_PER_COMMAND={0}'.format(
                         compute_threads(kwargs.get('ppj'), ncores)),
@@ -544,9 +545,8 @@ def qbatchDriver(**kwargs):
                                   " but qsub not found")
         which('qstat') or sys.exit("qbatch: error: QBATCH_SYSTEM set to"
                                    " pbs/sge but qstat not found")
-    else:
-        which('parallel') or sys.exit("qbatch: error: QBATCH_SYSTEM set to"
-                                      " local but parallel not found")
+
+    which('parallel') or sys.exit("qbatch: error: gnu-parallel not found")
 
     # execute the job script(s)
     for script in job_scripts:


### PR DESCRIPTION
which is a program, not a built-in, use the posix built-in "command -v" instead

we should always check for parallel, its used for all job submission types