### PR TITLE
Enable use of None for memory to account for slurm's 0 for whole-node memory

### DIFF
--- a/qbatch/qbatch.py
+++ b/qbatch/qbatch.py
@@ -39,7 +39,8 @@ def _setupVars():
     global MEMVARS
     MEMVARS = os.environ.get("QBATCH_MEMVARS", "mem")
     global MEM
-    MEM = os.environ.get("QBATCH_MEM", "0")
+    MEM = os.environ.get("QBATCH_MEM", None)
+    MEM = None if MEM == 'None' else MEM
     global SCRIPT_FOLDER
     SCRIPT_FOLDER = os.environ.get("QBATCH_SCRIPT_FOLDER", ".qbatch/")
     global QUEUE
@@ -318,7 +319,7 @@ def qbatchDriver(**kwargs):
     ncores = kwargs.get('cores')
     ppj = kwargs.get('ppj')
     job_name = kwargs.get('jobname')
-    mem = kwargs.get('mem') != '0' and kwargs.get('mem') or None
+    mem = None if kwargs.get('mem') == 'None' else kwargs.get('mem')
     queue = kwargs.get('queue')
     verbose = kwargs.get('verbose')
     dry_run = kwargs.get('dryrun')


### PR DESCRIPTION
This is a breaking change, so I'm going to start a v2.2 branch to merge changes which break backwards compatibility.