### PR TITLE
Fix task_list referenced before assigned error

### DIFF
--- a/qbatch/qbatch.py
+++ b/qbatch/qbatch.py
@@ -397,6 +397,7 @@ def qbatchDriver(**kwargs):
                     sys.exit("qbatch: error: command_file {0}".format(file) +
                              " does not exist or cannot be read")
     else:
+        task_list = kwargs.get('task_list')
         job_name = job_name or 'qbatchDriver'
 
     # compute the number of jobs needed. This will be the number of elements in


### PR DESCRIPTION
When trying to run qbatchDriver in pure python you end up in this conditional branch where `task_list` isn't defined but the next line checks its length. This should fix it.