### PR TITLE
Improve parallel call to avoid empty logfiles

### DIFF
--- a/qbatch/qbatch.py
+++ b/qbatch/qbatch.py
@@ -548,7 +548,7 @@ def qbatchDriver(**kwargs):
                         ncores)),
                 'sed -n "$(( (${ARRAY_IND} - 1) * ${CHUNK_SIZE} + 1 )),'
                 '+$(( ${CHUNK_SIZE} - 1 ))p" << EOF | parallel -j${CORES}'
-                ' --tag --line-buffer --compress',
+                ' --tag --lb',
                 ''.join(task_list),
                 'EOF']
 
@@ -579,8 +579,7 @@ def qbatchDriver(**kwargs):
                         'CORES={0}'.format(ncores),
                         'export THREADS_PER_COMMAND={0}'.format(
                             compute_threads(kwargs.get('ppj'), ncores)),
-                        "parallel -j${CORES} --tag --line-buffer"
-                        " --compress << EOF",
+                        "parallel -j${CORES} --tag --lb << EOF",
                         ''.join(task_list[chunk * chunk_size:chunk *
                                           chunk_size + chunk_size]),
                         'EOF']


### PR DESCRIPTION
Seems this wasn't fixed the first time